### PR TITLE
Error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ pom.xml.asc
 .hgignore
 .hg/
 /resources/js/
+/resources/.github-token
 node_modules/

--- a/demo/artemis/demo.cljs
+++ b/demo/artemis/demo.cljs
@@ -1,0 +1,76 @@
+(ns artemis.demo
+  (:require-macros [cljs.core.async.macros :refer [go-loop]]
+                   [artemis.github-token :refer [github-token]])
+  (:require [artemis.core :as a]
+            [artemis.stores.normalized-in-memory-store :as nms]
+            [artemis.network-steps.http :as http]
+            [artemis.network-steps.protocols :as np]
+            [artemis.document :refer [parse-document]]
+            [cljs.core.async :refer [<!]]))
+
+;; Create a standard store
+(def s (nms/create-store))
+
+;; Create a network step that adds oauth token to all requests
+(defn add-token [next-step]
+  (reify
+    np/GQLNetworkStep
+    (-exec [_ operation context]
+      (let [up-context (assoc context
+                              :interchange-format :transit
+                              :with-credentials? false
+                              :oauth-token       (github-token))] ;; Make sure your token exists inside of resources/.github-token
+        (np/-exec next-step operation up-context)))))
+
+;; Create a network chain using the base http step and the above add-token step
+(def n (-> (http/create-network-step "https://api.github.com/graphql")
+            add-token))
+
+;; Create the client
+(def c (a/create-client s n))
+
+;; Write a GraphQL query
+(def doc
+  (parse-document
+   "query {
+      repository(owner: \"octocat\", name: \"Hello-World\") {
+        id
+        name
+        description
+        createdAt
+        url
+        sshUrl
+        pushedAt
+        labels(first:5) {
+          nodes {
+            id
+            name
+            repository {
+              id
+              name
+            }
+          }
+        }
+        stargazers(first:5) {
+          nodes {
+            id
+            name
+            email
+              repositories(first:2) {
+                nodes {
+                  id
+                  name
+                }
+              }
+          }
+        }
+      }
+    }"))
+
+;; Run the query
+(defn query! []
+  (let [c (a/query c doc :fetch-policy :remote-only)]
+    (go-loop []
+      (when-let [result (<! c)]
+        (.log js/console result)
+        (recur)))))

--- a/demo/artemis/github_token.clj
+++ b/demo/artemis/github_token.clj
@@ -1,0 +1,4 @@
+(ns artemis.github-token)
+
+(defmacro github-token []
+  (slurp (clojure.java.io/resource ".github-token")))

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.9.946"]
                  [alumbra/parser "0.1.7"]
+                 [alumbra/errors "0.1.1"]
                  [cljs-http "0.1.44"]]
   :plugins [[lein-figwheel "0.5.14"]
             [lein-cljsbuild "1.1.7"]
@@ -16,19 +17,21 @@
             "test-jvm" ["with-profile" "test" "doo" "rhino" "test" "once"]}
   :clean-targets ^{:protect false} [:target-path "resources/js"]
   :profiles
-  {:demo  {:figwheel
+  {:demo  {:dependencies [[binaryage/devtools "0.9.9"]]
+           :figwheel
            {:server-port 8000
             :http-server-root "."}
            :cljsbuild
            {:builds
             {:dev
-             {:source-paths ["src"]
+             {:source-paths ["src" "demo"]
               :figwheel true
               :compiler {:output-to "resources/js/main.js"
                          :output-dir "resources/js"
                          :asset-path "js/"
-                         :main artemis.core
-                         :optimizations :none}}}}}
+                         :main artemis.demo
+                         :optimizations :none
+                         :preloads [devtools.preload]}}}}}
    :test {:dependencies [[org.mozilla/rhino "1.7.7"]
                          [org.clojure/test.check "0.9.0"]
                          [orchestra "2017.11.12-1"]]

--- a/src/artemis/document.cljc
+++ b/src/artemis/document.cljc
@@ -2,6 +2,7 @@
   #?(:cljs (:require-macros artemis.document))
   (:require [clojure.spec.alpha :as s]
             #?@(:clj [[alumbra.parser :as a]
+                      [alumbra.errors :as ae]
                       [clojure.walk :as w]])))
 
 (defn- remove-namespace [x]
@@ -53,9 +54,7 @@
      (let [parsed (a/parse-document source)]
        (if (contains? parsed :alumbra/parser-errors)
          (throw (ex-info "Unable to parse source."
-                         (merge {:reason    ::invalid-source
-                                 :attribute 'source
-                                 :value     source}
-                                parsed)))
+                         {:reason  ::invalid-source
+                          :errors  (vec (ae/explain-data parsed source))}))
          (let [ast (w/postwalk remove-namespace parsed)]
            (Document. ast source))))))

--- a/src/artemis/network_steps/http.cljs
+++ b/src/artemis/network_steps/http.cljs
@@ -1,31 +1,48 @@
 (ns artemis.network-steps.http
+  (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [cljs-http.client :as http]
             [artemis.document :as d]
-            [artemis.network-steps.protocols :as np]))
+            [artemis.result :as ar]
+            [artemis.network-steps.protocols :as np]
+            [cljs.core.async :as async]))
 
 (defn- payload [{:keys [document variables]}]
-  {:payload
-   {:query     (d/source document)
-    :variables variables}})
+  {:query     (d/source document)
+   :variables variables})
+
+(defn- post-operation [this operation {:keys [interchange-format]
+                                       :or   {interchange-format :json}
+                                       :as   context}]
+  (let [[params accept] (case interchange-format
+                          :json [:json-params "application/json"]
+                          :edn  [:edn-params "application/edn"]
+                          (throw (ex-info (str "Invalid data interchange format. "
+                                               "Must be one of #{:json :edn}.")
+                                          {:value  interchange-format})))]
+    (http/post
+      (:url this)
+      (-> context
+          (select-keys [:with-credentials? :oauth-token :basic-auth :headers])
+          (merge {:accept accept
+                  params  (payload operation)})))))
 
 (defrecord HttpNetworkStep [url]
   np/GQLNetworkStep
-  (-exec [this operation {:keys [interchange-format]
-                          :or   {interchange-format :json}
-                          :as   context}]
-    (let [[params accept] (case interchange-format
-                            :json [:json-params "application/json"]
-                            :edn  [:edn-params "application/edn"]
-                            (throw (ex-info "Invalid data interchange format.
-                                            Must be one of #{:json :edn}."
-                                            {:reason ::invalid-interchange-format
-                                             :value  interchange-format})))]
-      (http/post
-       (:url this)
-       (-> context
-           (select-keys [:with-credentials? :oauth-token :basic-auth :headers])
-           (merge {:accept accept
-                   params  (payload operation)}))))))
+  (-exec [this operation context]
+    (try
+      (let [c (post-operation this operation context)]
+        (go (let [{:keys [body error-code] :as res} (async/<! c)
+                  net-error   (when (not= error-code :no-error)
+                                {:message (str "Network error " error-code)
+                                 :response res})
+                  data        (:data body)
+                  errors      (into (:errors body) net-error)]
+              (ar/with-errors {:data data} errors))))
+      (catch :default e
+        (async/to-chan
+         [(ar/with-errors
+           {:data nil}
+           [(assoc (ex-data e) :message (.-message e))])])))))
 
 ;; Public API
 (defn create-network-step

--- a/src/artemis/result.cljs
+++ b/src/artemis/result.cljs
@@ -1,0 +1,13 @@
+(ns artemis.result)
+
+(defn with-errors
+  [result errors]
+  (if (empty? errors)
+    result
+    (update result :errors concat errors)))
+
+(defn result->message
+  [result]
+  (-> result
+      (select-keys [:data :errors])
+      (update :data identity)))

--- a/test/artemis/core_test.cljs
+++ b/test/artemis/core_test.cljs
@@ -7,6 +7,7 @@
             [clojure.test.check.generators]
             [artemis.core :as core]
             [artemis.document :refer [parse-document]]
+            [artemis.result :refer [with-errors]]
             [artemis.stores.protocols :as sp]
             [artemis.network-steps.protocols :as np]))
 
@@ -17,7 +18,9 @@
 (defn- stub-store [c]
   (reify sp/GQLStore
     (-query [_ doc variables _]
-      (get-in c [:heros (:episode variables)]))))
+      (let [result (get-in c [:heros (:episode variables)])]
+        (cond-> {:data result}
+          (nil? result) (with-errors [{:message "Couldn't find hero"}]))))))
 
 (deftest create-client
   (is (some? (core/create-client)))
@@ -52,32 +55,45 @@
 (deftest query-local-only-cached
   (testing "local-only when data available"
     (async done
-      (go (let [result (<! (query :local-only))]
+      (go (let [local-chan (query :local-only)
+                result     (<! local-chan)
+                closed?    (nil? (<! local-chan))]
             (is (= (:data result) "Luke Skywalker"))
             (is (= (:variables result) variables))
+            (is (= (:source result) :local))
             (is (= (:network-status result) :ready))
             (is (false? (:in-flight? result)))
+            (is closed?)
             (done))))))
 
 (deftest query-local-only-not-cached
   (testing "local-only when data not available"
     (async done
-      (go (let [result (<! (uc-query :local-only))]
+      (go (let [local-chan (uc-query :local-only)
+                result     (<! local-chan)
+                closed?    (nil? (<! local-chan))]
             (is (nil? (:data result)))
-            (is (= "fail" (:error result)))
+            (is (= 1 (count (:errors result))))
             (is (= (:variables result) uc-variables))
+            (is (= (:source result) :local))
             (is (= (:network-status result) :ready))
             (is (false? (:in-flight? result)))
+            (is closed?)
             (done))))))
 
 (deftest query-local-first-cached
   (testing "local-first when data available"
     (async done
-      (go (let [result (<! (query :local-first))]
+      (go (let [local-chan (query :local-first)
+                result     (<! local-chan)
+                closed?    (nil? (<! local-chan))]
             (is (= (:data result) "Luke Skywalker"))
+            (is (nil? (:errors result)))
             (is (= (:variables result) variables))
+            (is (= (:source result) :local))
             (is (= (:network-status result) :ready))
             (is (false? (:in-flight? result)))
+            (is closed?)
             (done))))))
 
 (deftest query-local-first-not-cached
@@ -85,72 +101,88 @@
     (async done
       (let [result-chan (uc-query :local-first)]
         (go (let [local-result  (<! result-chan)
-                  remote-result (<! result-chan)]
+                  remote-result (<! result-chan)
+                  closed?       (nil? (<! result-chan))]
               (is (nil? (:data local-result)))
               (is (= (:variables local-result) uc-variables))
-              (is (= (:network-status local-result) :loading))
+              (is (= (:source local-result) :local))
+              (is (= (:network-status local-result) :fetching))
               (is (true? (:in-flight? local-result)))
 
               (is (= (:data remote-result) "Luke Skywalker"))
               (is (= (:variables remote-result) uc-variables))
+              (is (= (:source remote-result) :remote))
               (is (= (:network-status remote-result) :ready))
               (is (false? (:in-flight? remote-result)))
+              (is closed?)
               (done)))
-        (put! mock-chan "Luke Skywalker")))))
+        (put! mock-chan {:data "Luke Skywalker"})))))
 
 (deftest query-local-then-remote-cached
   (testing "local-then-remote when data available"
     (async done
       (let [result-chan (query :local-then-remote)]
         (go (let [local-result  (<! result-chan)
-                  remote-result (<! result-chan)]
+                  remote-result (<! result-chan)
+                  closed?       (nil? (<! result-chan))]
               (is (= (:data local-result) "Luke Skywalker"))
               (is (= (:variables local-result) variables))
-              (is (= (:network-status local-result) :loading))
+              (is (= (:source local-result) :local))
+              (is (= (:network-status local-result) :fetching))
               (is (true? (:in-flight? local-result)))
 
               (is (= (:data remote-result) "Luke Skywalker"))
               (is (= (:variables remote-result) variables))
+              (is (= (:source remote-result) :remote))
               (is (= (:network-status remote-result) :ready))
               (is (false? (:in-flight? remote-result)))
+              (is closed?)
               (done)))
-        (put! mock-chan "Luke Skywalker")))))
+        (put! mock-chan {:data "Luke Skywalker"})))))
 
 (deftest query-local-then-remote-not-cached
   (testing "local-then-remote when data not available"
     (async done
       (let [result-chan (uc-query :local-then-remote)]
         (go (let [local-result  (<! result-chan)
-                  remote-result (<! result-chan)]
+                  remote-result (<! result-chan)
+                  closed?       (nil? (<! result-chan))]
               (is (nil? (:data local-result)))
               (is (= (:variables local-result) uc-variables))
-              (is (= (:network-status local-result) :loading))
+              (is (= (:source local-result) :local))
+              (is (= (:network-status local-result) :fetching))
               (is (true? (:in-flight? local-result)))
 
               (is (= (:data remote-result) "Luke Skywalker"))
               (is (= (:variables remote-result) uc-variables))
+              (is (= (:source remote-result) :remote))
               (is (= (:network-status remote-result) :ready))
               (is (false? (:in-flight? remote-result)))
+              (is closed?)
               (done)))
-        (put! mock-chan "Luke Skywalker")))))
+        (put! mock-chan {:data "Luke Skywalker"})))))
 
 (deftest query-remote-only
   (async done
     (let [result-chan (query :remote-only)]
       (go (let [local-result  (<! result-chan)
-                remote-result (<! result-chan)]
+                remote-result (<! result-chan)
+                closed?       (nil? (<! result-chan))]
             (is (nil? (:data local-result)))
             (is (= (:variables local-result) variables))
-            (is (= (:network-status local-result) :loading))
+            (is (= (:source local-result) :local))
+            (is (= (:network-status local-result) :fetching))
             (is (true? (:in-flight? local-result)))
 
             (is (= (:data remote-result) "Luke Skywalker"))
             (is (= (:variables remote-result) variables))
+            (is (= (:source remote-result) :remote))
             (is (= (:network-status remote-result) :ready))
             (is (false? (:in-flight? remote-result)))
+            (is closed?)
             (done)))
-      (put! mock-chan "Luke Skywalker"))))
+      (put! mock-chan {:data "Luke Skywalker"}))))
 
 (deftest query-invalid
-  (is (thrown-with-msg? ExceptionInfo #"Invalid :fetch-policy provided"
+  (is (thrown-with-msg? ExceptionInfo #"Invalid :fetch-policy"
                         (query :something-else))))


### PR DESCRIPTION
Most of this around adding handling errors:

- If you incorrectly call `artemis.core/query`a run-time exception will be thrown
- If you correctly call `artemis.core/query` the store and network chains are responsible for generating GraphQL errors. Stores and network steps should return a map with `:data` and optional `:errors` key. A util `artemis.result/with-errors` makes it easier to stick to this. With this, we stick to the pattern where GraphQL errors don't mean runtime exceptions but instead allow the client to handle the given errors ad-hoc.

Also added a couple of tests here for the core api and committed the demo (updated it to run against the public github graphql api)