### PR TITLE
Subscriptions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,5 +2,6 @@
  :deps  {org.clojure/clojure       {:mvn/version "1.9.0"}
          org.clojure/clojurescript {:mvn/version "1.9.946"}
          cljs-http                 {:mvn/version "0.1.44"}
+         haslett                   {:mvn/version "0.1.2"}
          alumbra/parser            {:mvn/version "0.1.7"}
          alumbra/errors            {:mvn/version "0.1.1"}}}

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
   [[org.clojure/clojure       "1.9.0"]
    [org.clojure/clojurescript "1.9.946"]
    [cljs-http                 "0.1.44"]
+   [haslett                   "0.1.2"]
    [alumbra/parser            "0.1.7"]
    [alumbra/errors            "0.1.1"]]
 

--- a/src/artemis/network_steps/http.cljs
+++ b/src/artemis/network_steps/http.cljs
@@ -49,7 +49,7 @@
 
 ;; Public API
 (defn create-network-step
-  "Returns a new `HttpNetworkStep` for a given uri The uri defaults to
+  "Returns a new `HttpNetworkStep` for a given uri. The uri defaults to
   `\"/graphql\"`. Makes requests via cljs-http."
   {:added "0.1.0"}
   ([]

--- a/src/artemis/network_steps/ws_subscription.cljs
+++ b/src/artemis/network_steps/ws_subscription.cljs
@@ -1,0 +1,155 @@
+(ns artemis.network-steps.ws-subscription
+  (:require-macros [cljs.core.async.macros :refer [go]])
+  (:require [haslett.client :as ws]
+            [haslett.format :as fmt]
+            [artemis.core :as a]
+            [artemis.document :as d]
+            [artemis.result :as ar]
+            [artemis.network-steps.protocols :as np]
+            [cljs.core.async :as async]))
+
+(defonce ws-conn     (atom nil))
+(defonce live-subs   (atom {}))
+(defonce subs-buffer (atom {}))
+
+(defn- payload [{:keys [document variables]}]
+  {:query     (d/source document)
+   :variables variables})
+
+(defn log-dupe! [msg]
+  (when ^boolean goog.DEBUG
+    (.info js/console (str "%c[ARTEMIS] " msg) "color: orange;")))
+
+(defn- kebab-keyword [s]
+  (when s
+    (-> s (.replace #"_" "-") keyword)))
+
+(def ^:private ws-txf
+  (map
+   (fn [{:keys [type payload]}]
+     (let [message    (if (= type "error")
+                        (ar/with-errors {:data nil} [payload])
+                        {:data (:data payload)})
+           ws-status  (if @ws-conn :connected :disconnected)]
+       (assoc message :ws-status  ws-status
+                      :ws-message (kebab-keyword type))))))
+
+(defn- start-subscription [stream operation chan+id]
+  (if (contains? @live-subs operation)
+    (log-dupe! (str "Ignoring duplicate subscription: " (:id chan+id)))
+    (do (swap! live-subs assoc operation chan+id)
+        (go (async/>! (:sink stream)
+                      {:id      (:id chan+id)
+                       :type    "start"
+                       :payload (payload operation)})
+            (async/pipeline 1 (:chan chan+id) ws-txf (:source stream) false) ; false only when reconnect false?
+            ))))
+
+(defrecord
+  ^{:added "0.1.0"}
+  WSSubscriptionStep
+  []
+  np/GQLNetworkStep
+  (-exec [this operation context]
+    (let [c       (async/chan)
+          stream  @ws-conn
+          chan+id {:chan c, :id (:ws-sub-id context)}]
+      (if stream
+        (start-subscription stream operation chan+id)
+        (swap! subs-buffer conj [operation chan+id]))
+      c)))
+
+(defn- flush-buffer! [stream]
+  (doseq [[operation chan+id] @subs-buffer]
+    (start-subscription stream operation chan+id)))
+
+(defn- shake-hands!
+  "Establishes the WebSocket connection and puts an initializing message. The
+  connection stream is added to the registry and any subscriptions that have
+  been buffered until connection ready are flushed."
+  [uri init-payload formatter reconnect?]
+  (when-not @ws-conn
+    (go (let [stream (async/<! (ws/connect uri {:format    formatter
+                                                :protocols ["graphql-ws"]}))]
+          (async/>! (:sink stream)
+                    {:type    "connection_init"
+                     :payload init-payload})
+          (reset! ws-conn stream)
+          (flush-buffer! stream)
+          (when reconnect?
+            (let [_ (async/<! (:close-status stream))]
+              (reset! ws-conn nil)
+              (reset! subs-buffer @live-subs)
+              (reset! live-subs {})
+              (shake-hands! uri init-payload formatter reconnect?)))))))
+
+(def ^:private json-formatter
+  (reify fmt/Format
+    (read  [_ s] (js->clj (.parse js/JSON s) :keywordize-keys true))
+    (write [_ v] (.stringify js/JSON (clj->js v)))))
+
+;; Public API
+(defn create-ws-subscription-step
+  "Returns a new `WSSubscriptionStep` for a given uri and options. The uri
+  defaults to `\"/graphql/subscriptions\"`. Uses haslett channels for WebSocket
+  connection and exchange."
+  {:added "0.1.0"}
+  ([]
+   (create-ws-subscription-step "/graphql/subscriptions"))
+  ([uri & {:keys [interchange-format init-payload reconnect?]
+           :or   {interchange-format :json
+                  init-payload       {}
+                  reconnect?         true}}]
+   (let [formatter (case interchange-format
+                     :json json-formatter
+                     :edn  fmt/edn
+                     (throw (ex-info (str "Invalid data interchange format. "
+                                          "Must be one of #{:json :edn}.")
+                                     {:value  interchange-format})))
+         step      (WSSubscriptionStep.)]
+     (shake-hands! uri init-payload formatter reconnect?)
+     step)))
+
+(defn with-ws-subscriptions
+  "Returns a network chain that directs subcription operations to the
+  ws-sub-step and all others to the http-step."
+  {:added "0.1.0"}
+  [http-step ws-sub-step]
+  (reify
+    np/GQLNetworkStep
+    (-exec [_ operation context]
+      (let [next-step (if (:ws-sub-id context) ws-sub-step http-step)]
+        (a/exec next-step operation context)))))
+
+(defn close-connection!
+  "Closes the WebSocket connection and returns a channel with the status at
+  close."
+  {:added "0.1.0"}
+  []
+  (let [return (ws/close @ws-conn)
+        unsubs @live-subs]
+    (reset! ws-conn false) ; set to false so that we don't try to reconnect
+    (reset! subs-buffer {})
+    (reset! live-subs {})
+    (doseq [[_ {:keys [chan]}] unsubs]
+      (go (async/>! chan {:data nil, :ws-status :manually-closed, :ws-message nil})
+          (async/close! chan)))
+    return))
+
+(defn- find-sub [id]
+  (->> @live-subs
+       (filter (fn [[_ chan+id]] (= (:id chan+id) id)))
+       first))
+
+(defn unsubscribe!
+  "Given a `ws-id`, find the subscription and close the channel, remove from
+  the live-subs registry, and send a stop message to the server."
+  {:added "0.1.0"}
+  [ws-id]
+  (when-let [stream @ws-conn]
+    (when-let [[operation chan+id] (find-sub ws-id)]
+      (swap! live-subs dissoc operation)
+      (async/close! (:chan chan+id))
+      (go (async/>! (:sink stream)
+                    {:id   (:id chan+id)
+                     :type "stop"})))))

--- a/src/artemis/result.cljs
+++ b/src/artemis/result.cljs
@@ -9,10 +9,7 @@
     (update result :errors concat errors)))
 
 (defn result->message
-  "Takes a result and returns a map containing at least a `:data` key and
-  nothing in addition to `:data` and `:errors` keys."
+  "Takes a result and returns a map containing at least a `:data`."
   {:added "0.1.0"}
   [result]
-  (-> result
-      (select-keys [:data :errors])
-      (update :data identity)))
+  (-> result (update :data identity)))

--- a/test/artemis/core_subscribe_test.cljs
+++ b/test/artemis/core_subscribe_test.cljs
@@ -1,0 +1,35 @@
+(ns artemis.core-subscribe-test
+  (:require-macros [cljs.core.async.macros :refer [go-loop]])
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [cljs.core.async :refer [chan <! put!]]
+            [artemis.core :as core]
+            [artemis.test-util :as tu :refer [with-client]]))
+
+(deftest subscribe
+  (async done
+    (with-client
+     (let [variables   {:some :var}
+           result-chan (core/subscribe! client tu/subscription-doc variables)]
+       (go-loop [n 0]
+         (if (< n 4)
+           (when-let [result (<! result-chan)]
+             (if (zero? n)
+               (do (is (nil? (:data result)))
+                   (is (= (:variables result) variables))
+                   (is (= (:ws-status result) :connected))
+                   (is (= (:ws-message result) :init)))
+               (do (is (= (:data result) n))
+                   (is (= (:variables result) variables))
+                   (is (= (:ws-status result) :connected))
+                   (is (= (:ws-message result) :data))))
+             (recur (inc n)))
+           (done))))
+
+     ;; Putting a few fake sub events
+     (put-result! {:data       nil
+                   :ws-status  :connected
+                   :ws-message :init})
+     (doseq [n (range 1 4)]
+       (put-result! {:data       n
+                     :ws-status  :connected
+                     :ws-message :data})))))

--- a/test/artemis/test_runner.cljs
+++ b/test/artemis/test_runner.cljs
@@ -3,6 +3,7 @@
             [artemis.core-test]
             [artemis.core-mutate-test]
             [artemis.core-query-test]
+            [artemis.core-subscribe-test]
             [artemis.stores.mapgraph-store-test]
             [clojure.spec.alpha :as s]
             [orchestra-cljs.spec.test :as st]))
@@ -13,4 +14,5 @@
 (doo-tests 'artemis.core-test
            'artemis.core-mutate-test
            'artemis.core-query-test
+           'artemis.core-subscribe-test
            'artemis.stores.mapgraph-store-test)

--- a/test/artemis/test_util.clj
+++ b/test/artemis/test_util.clj
@@ -5,9 +5,9 @@
         opts  (if opts? (first args) {})
         body  (if opts? (next args) args)
         {:keys [store-query-fn store-write-fn]} opts]
-    `(let [mock-chan# (cljs.core.async/chan)
-           store# (stub-store ~store-query-fn ~store-write-fn)
-           nchain# (stub-net-chain mock-chan#)
+    `(let [mock-chan#    (cljs.core.async/chan)
+           store#        (stub-store ~store-query-fn ~store-write-fn)
+           nchain#       (stub-net-chain mock-chan#)
            ~'put-result! #(cljs.core.async/put! mock-chan# %)
-           ~'client (artemis.core/create-client :store store# :network-chain nchain#)]
+           ~'client      (artemis.core/create-client :store store# :network-chain nchain#)]
        ~@body)))

--- a/test/artemis/test_util.cljs
+++ b/test/artemis/test_util.cljs
@@ -38,3 +38,12 @@
         commentary
       }
     }"))
+
+(def subscription-doc
+  (parse-document
+    "subscription($id: ID!) {
+      messageAdded(channelId:$id) {
+        id
+        text
+      }
+    }"))


### PR DESCRIPTION
Adds `artemis.core/subscribe!`, which sets up a GraphQL subscription via WS. By doing a `go-loop` around the channel returned from `subscribe!` you get a stream of subscription event updates.

Using https://github.com/weavejester/haslett for the WS stuff because it feels like the WS version of cljs-http.