### PR TITLE
Configurable entity references in mapgraph store

### DIFF
--- a/src/artemis/stores/mapgraph/common.cljs
+++ b/src/artemis/stores/mapgraph/common.cljs
@@ -3,9 +3,6 @@
 (defn map-vals [m f] (into {} (for [[k v] m] [k (f v)])))
 (defn map-keys [m f] (into {} (for [[k v] m] [(f k) v])))
 
-(defn- seek [pred s]
-  (some #(when (pred %) %) s))
-
 (defn- possible-entity-map?
   "True if x is a non-sorted map. This check prevents errors from
   trying to compare keywords with incompatible keys in sorted maps."
@@ -13,19 +10,10 @@
   (and (map? x)
        (not (sorted? x))))
 
-(defn- find-id-key
-  "Returns the first identifier key found in map, or nil if it is not
-  a valid entity map."
-  [map id-attrs]
-  (when (possible-entity-map? map)
-    (seek #(contains? map %) id-attrs)))
-
-(defn get-ref
-  "Returns a lookup ref for the map, given a collection of identifier
-  keys, or nil if the map does not have an identifier key."
-  [map id-attrs]
-  (when-let [k (find-id-key map id-attrs)]
-    [k (get map k)]))
+(defn get-ref [m {:keys [cache-key id-fn]}]
+  (when (possible-entity-map? m)
+    (when-let [f (or (cache-key m) (id-fn m))]
+      {:artemis.mapgraph/ref f})))
 
 (defn like
   "Returns a collection of the same type as type-coll (vector, set,

--- a/src/artemis/stores/mapgraph/core.cljs
+++ b/src/artemis/stores/mapgraph/core.cljs
@@ -13,7 +13,7 @@
            field isn't returned in a query, the cache will store the field with
            a generic key and it will not be retrievable via a normal look up."}
   MapGraphStore
-  [id-attrs entities cache-key]
+  [id-fn entities cache-key]
   sp/GQLStore
   (-read [this document variables return-partial?]         ;todo: implement return-partial
     {:data (not-empty (read-from-cache document variables this))})
@@ -34,7 +34,7 @@
   [store]
   (and (instance? MapGraphStore store)
        (satisfies? sp/GQLStore store)
-       (set? (:id-attrs store))
+       (fn? (:id-fn store))
        (map? (:entities store))))
 
 (defn create-store
@@ -45,15 +45,14 @@
   - `:cache-key` The default generic key for the store's cache. Defaults to
                  `:artemis.stores.mapgrah.core/cache`."
   {:added "0.1.0"}
-  [& {:keys [id-attrs entities cache-key]
-      :or   {id-attrs  #{}
+  [& {:keys [id-fn entities cache-key]
+      :or   {id-fn     :id
              entities  {}
              cache-key ::cache}}]
-  (let [cache-key (or cache-key ::cache)]
-    (MapGraphStore. (conj id-attrs cache-key) entities cache-key)))
+  (MapGraphStore. id-fn entities cache-key))
 
 (defn clear
-  "Returns a store with unique indexes and entities cleared out."
+  "Returns a store with entities cleared out."
   {:added "0.1.0"}
   [store]
-  (assoc store :entities {} :id-attrs #{}))
+  (assoc store :entities {}))

--- a/src/artemis/stores/mapgraph/read.cljs
+++ b/src/artemis/stores/mapgraph/read.cljs
@@ -7,23 +7,16 @@
   "Returns true if map is an entity according to the db schema. An
   entity is a map from keywords to values with exactly one identifier
   key."
-  [store map]
+  [{:keys [id-fn]} map]
   (and (map? map)
+       (not (sorted? map))
        (every? keyword? (keys map))
-       (= 1 (count (filter #(contains? map %) (:id-attrs store))))))
-
-(defn- ref-to
-  "Returns a lookup ref for the entity using the schema in db, or nil
-  if not found. The db does not need to contain the entity."
-  [store entity]
-  (get-ref entity (:id-attrs store)))
+       (some? (id-fn map))))
 
 (defn- ref?
   "Returns true if ref is a lookup ref according to the db schema."
   [store ref]
-  (and (vector? ref)
-       (= 2 (count ref))
-       (contains? (:id-attrs store) (first ref))))
+  (boolean (:artemis.mapgraph/ref ref)))
 
 (defn- modify-entity-for-gql                                 ;todo: fix how wasteful and unperformant this is
   "Converts the selection's key in entity to what it would be in a normal gql response"
@@ -119,7 +112,7 @@
      must all be gql selections from the generated ast. There's no support for
      handling pull patterns that are combination of selections and normal keys"
   [{:keys [entities] :as store} pattern lookup-ref & [gql-context]]
-  (when-let [entity (get entities lookup-ref)]
+  (when-let [entity (get entities (:artemis.mapgraph/ref lookup-ref))]
     (reduce
       (fn [result expr]
         (let [{:keys [expr entity selection]} (expr-and-entity-for-gql expr entity gql-context)]
@@ -154,7 +147,7 @@
                  :vars-info (:variable-definitions first-op) ; info about the kinds of variables supported by this op
                  :store store}
         pull-pattern (->gql-pull-pattern first-op fragments)]
-    (pull store pull-pattern [(:cache-key store) "root"] context)))
+    (pull store pull-pattern {:artemis.mapgraph/ref "root"} context)))
 
 (defn read-from-entity
   [document ent-ref store]
@@ -162,4 +155,4 @@
         fragments (fragments-map document)
         context {:input-vars {} :vars-info nil :store store}
         pull-pattern (->gql-pull-pattern first-frag fragments)]
-    (pull store pull-pattern ent-ref context)))
+    (pull store pull-pattern {:artemis.mapgraph/ref ent-ref} context)))

--- a/src/artemis/stores/mapgraph/read.cljs
+++ b/src/artemis/stores/mapgraph/read.cljs
@@ -4,9 +4,8 @@
             [artemis.stores.mapgraph.selections :as sel :refer [field-key aliased? ref-join-expr]]))
 
 (defn- entity?
-  "Returns true if map is an entity according to the db schema. An
-  entity is a map from keywords to values with exactly one identifier
-  key."
+  "Returns true if map is an entity. An entity is a map from keywords to values
+  with an existing id according to the db id-fn."
   [{:keys [id-fn]} map]
   (and (map? map)
        (not (sorted? map))
@@ -14,7 +13,7 @@
        (some? (id-fn map))))
 
 (defn- ref?
-  "Returns true if ref is a lookup ref according to the db schema."
+  "Returns true if ref is a lookup ref."
   [store ref]
   (boolean (:artemis.mapgraph/ref ref)))
 

--- a/src/artemis/stores/mapgraph/selections.cljs
+++ b/src/artemis/stores/mapgraph/selections.cljs
@@ -81,9 +81,15 @@
   (when-let [sel-set (:selection-set sel)]
     (reduce (fn [acc sel]
               (if (keyword-identical? (:node-type sel) :inline-fragment)
-                (if (= (:type-name (:type-condition sel)) (:__typename v))
-                  (into acc (:selection-set sel))
-                  acc)
+                (if-let [typename (:__typename v)]
+                  (if (= (:type-name (:type-condition sel)) typename)
+                    (into acc (:selection-set sel))
+                    acc)
+                  (throw (ex-info "union type used, but typename not specified"
+                                  {:reason     ::missing-typename
+                                   ::entity    v
+                                   ::attribute :__typename
+                                   ::value     nil})))
                 (conj acc sel)))
             []
             sel-set)))

--- a/src/artemis/stores/mapgraph/selections.cljs
+++ b/src/artemis/stores/mapgraph/selections.cljs
@@ -96,7 +96,7 @@
     join-expr
     (reduce (fn [acc [condition selection]]
               (if (= (:type-name (:type-condition condition))
-                     (:__typename (get entities lookup-ref)))
+                     (:__typename (get entities (:artemis.mapgraph/ref lookup-ref))))
                 (reduced (into acc selection))
                 acc))
             []

--- a/src/artemis/stores/mapgraph/write.cljs
+++ b/src/artemis/stores/mapgraph/write.cljs
@@ -13,26 +13,26 @@
   [m k f x]
   (assoc! m k (f (get m k) x)))
 
-(defn- ref-and-val [id-attrs val]
-  {:ref (get-ref val id-attrs) :val val})
+(defn- ref-and-val [store val]
+  {:ref (get-ref val store) :val val})
 
 (defn- normalize-entities
   "Returns a sequence of normalized entities starting with map m."
-  [m id-attrs]
+  [m store]
   (lazy-seq
     (loop [sub-entities (transient [])
            normalized (transient {})
            kvs (seq m)]
       (if-let [[k v] (first kvs)]
         (if (map? v)
-          (if-let [r (get-ref v id-attrs)]
+          (if-let [r (get-ref v store)]
             ;; v is a single entity
             (recur (conj! sub-entities v)
                    (assoc! normalized k r)
                    (rest kvs))
             ;; v is a map, not an entity
             (let [values (vals v)]
-              (if-let [refs (seq (keep #(get-ref % id-attrs) values))]
+              (if-let [refs (seq (keep #(get-ref % store) values))]
                 ;; v is a map whose values are entities
                 (do (when-not (= (count refs) (count v))
                       (throw (ex-info "Map values may not mix entities and non-entities"
@@ -49,7 +49,7 @@
                        (rest kvs)))))
           ;; v is not a map
           (if (coll? v)
-            (let [refs-and-vals (map (partial ref-and-val id-attrs) v)
+            (let [refs-and-vals (map (partial ref-and-val store) v)
                   new-v (map #(if-let [ref (:ref %)] ref (:val %)) refs-and-vals)
                   refs (->> refs-and-vals
                             (remove #(-> % :ref nil?))
@@ -62,29 +62,22 @@
                    (assoc! normalized k v)
                    (rest kvs))))
         (cons (persistent! normalized)
-              (mapcat #(normalize-entities % id-attrs)
+              (mapcat #(normalize-entities % store)
                       (persistent! sub-entities)))))))
-
-(defn add-id-attr
-  "Adds unique identity attributes to the db schema. Returns updated
-  db."
-  [store & id-keys]
-  (update store :id-attrs into id-keys))
 
 (defn add
   "Returns updated store with generic normalized entities merged in."
   [store & entities]
-  (let [id-attrs (:id-attrs store)]
-    (update
-      store
-      :entities
-      (fn transient-entities-update [ent-m]
-        (persistent!
-          (reduce (fn [m e]
-                    (let [ref (get-ref e id-attrs)]
-                      (update! m ref merge e)))
-                  (transient ent-m)
-                  (mapcat #(normalize-entities % id-attrs) entities)))))))
+  (update
+    store
+    :entities
+    (fn transient-entities-update [ent-m]
+      (persistent!
+        (reduce (fn [m e]
+                  (let [ref (get-ref e store)]
+                    (update! m (:artemis.mapgraph/ref ref) merge e)))
+                (transient ent-m)
+                (mapcat #(normalize-entities % store) entities))))))
 
 (defn- name-or-field-name [sel]
   (if (aliased? sel)
@@ -124,7 +117,7 @@
                                           (format-for-cache context (sel/selection-set sel v) v fragments nsed-key))]
                               (vector new-k new-v)))
                           result))]
-        (if (not (get-ref formatted (:id-attrs store)))
+        (if (not (get-ref formatted store))
           (assoc formatted (:cache-key store) stub)
           formatted))
       result)))

--- a/test/artemis/document_test.cljs
+++ b/test/artemis/document_test.cljs
@@ -69,8 +69,6 @@
                 :selection-set  [{:node-type  :field
                                   :field-name "a"}
                                  {:node-type  :field
-                                  :field-name "__typename"}
-                                 {:node-type  :field
                                   :field-name "b"}
                                  {:node-type  :field
                                   :field-name "c"}]}]}
@@ -93,8 +91,6 @@
                                   :field-name "a"}
                                  {:node-type  :field
                                   :field-name "b"}
-                                 {:node-type  :field
-                                  :field-name "__typename"}
                                  {:node-type  :field
                                   :field-name "c"}]}]}
              (d/inline-fragments doc))))))
@@ -204,8 +200,7 @@
                          :circle   "def"
                          :triangle "ghi"}}]
       (is (= (d/select doc data)
-             {:__typename nil
-              :alias      "Bob"
+             {:alias      "Bob"
               :email      nil}))
       (is (= (d/select doc data true)
              {:alias "Bob"})))))

--- a/test/artemis/stores/mapgraph_store_test.cljs
+++ b/test/artemis/stores/mapgraph_store_test.cljs
@@ -17,7 +17,7 @@
                :stringField "this is a string"
                :numberField 3
                :nullField   nil}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
@@ -36,7 +36,7 @@
                :stringField "The arg was 1"
                :numberField 3
                :nullField   nil}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id                        "abcd"
                 "stringField({\"arg\":1})" "The arg was 1"
                 :numberField               3
@@ -55,7 +55,7 @@
                :aliasedField "this is a string"
                :numberField  3
                :nullField    nil}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
@@ -76,7 +76,7 @@
                :aliasedField2 "The arg was 2"
                :numberField   3
                :nullField     nil}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id                        "abcd"
                 "stringField({\"arg\":1})" "The arg was 1"
                 "stringField({\"arg\":2})" "The arg was 2"
@@ -99,7 +99,7 @@
                  :stringField "This worked"
                  :numberField 5
                  :nullField   nil}
-    :entities   {[::cache "root"]
+    :entities   {"root"
                  {:id                                             "abcd"
                   :nullField                                      nil
                   "numberField({\"intArg\":5,\"floatArg\":3.14})" 5
@@ -124,7 +124,7 @@
                  :stringField "This worked"
                  :numberField 5
                  :nullField   nil}
-    :entities   {[::cache "root"]
+    :entities   {"root"
                  {:id                                                   "abcd"
                   :nullField                                            nil
                   "numberField({\"intArg\":5,\"floatArg\":3.14})"       5
@@ -143,7 +143,7 @@
                :firstName "James"
                :lastName  "BOND"
                :birthDate "20-05-1940"}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id                                                 "abcd"
                 :firstName                                          "James"
                 "lastName@upperCase"                                "BOND"
@@ -173,14 +173,14 @@
                              :numberField 3
                              :nullField   nil
                              :__typename  "object"}}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
                 :nullField   nil
-                :nestedObj   [:object/id "abcde"]
+                :nestedObj   {:artemis.mapgraph/ref "abcde"}
                 ::cache      "root"}
-               [:object/id "abcde"]
+               "abcde"
                {:object/id          "abcde"
                 :object/stringField "this is a string too"
                 :object/numberField 3
@@ -208,14 +208,14 @@
                              :numberField 3
                              :nullField   nil
                              :__typename  "object"}}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
                 :nullField   nil
-                :nestedObj   [::cache "root.nestedObj"]
+                :nestedObj   {:artemis.mapgraph/ref "root.nestedObj"}
                 ::cache      "root"}
-               [::cache "root.nestedObj"]
+               "root.nestedObj"
                {:object/stringField "this is a string too"
                 :object/numberField 3
                 :object/nullField   nil
@@ -243,14 +243,14 @@
                              :numberField 3
                              :nullField   nil
                              :__typename  "object"}}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id                            "abcd"
                 :stringField                   "this is a string"
                 :numberField                   3
                 :nullField                     nil
-                "nestedObj({\"arg\":\"val\"})" [::cache "root.nestedObj({\"arg\":\"val\"})"]
+                "nestedObj({\"arg\":\"val\"})" {:artemis.mapgraph/ref "root.nestedObj({\"arg\":\"val\"})"}
                 ::cache                        "root"}
-               [::cache "root.nestedObj({\"arg\":\"val\"})"]
+               "root.nestedObj({\"arg\":\"val\"})"
                {:object/stringField "this is a string too"
                 :object/numberField 3
                 :object/nullField   nil
@@ -285,21 +285,21 @@
                               :numberField 3
                               :nullField   nil
                               :__typename  "object"}]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 1
                 :nullField   nil
-                :nestedArray [[:object/id "abcde"]
-                              [:object/id "abcdef"]]
+                :nestedArray [{:artemis.mapgraph/ref "abcde"}
+                              {:artemis.mapgraph/ref "abcdef"}]
                 ::cache      "root"}
-               [:object/id "abcde"]
+               "abcde"
                {:object/id          "abcde"
                 :object/stringField "this is a string too"
                 :object/numberField 2
                 :object/nullField   nil
                 :__typename         "object"}
-               [:object/id "abcdef"]
+               "abcdef"
                {:object/id          "abcdef"
                 :object/stringField "this is a string also"
                 :object/numberField 3
@@ -330,14 +330,14 @@
                               :nullField   nil
                               :__typename  "object"}
                              nil]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 1
                 :nullField   nil
-                :nestedArray [[:object/id "abcde"] nil]
+                :nestedArray [{:artemis.mapgraph/ref "abcde"} nil]
                 ::cache      "root"}
-               [:object/id "abcde"]
+               "abcde"
                {:object/id          "abcde"
                 :object/stringField "this is a string too"
                 :object/numberField 2
@@ -387,51 +387,51 @@
                               :deeplyNestedArray []
                               :nullField         nil
                               :__typename        "object"}]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 1
                 :nullField   nil
-                :nestedArray [[::cache "root.nestedArray.0"]
-                              [::cache "root.nestedArray.1"]
-                              [::cache "root.nestedArray.2"]]
+                :nestedArray [{:artemis.mapgraph/ref "root.nestedArray.0"}
+                              {:artemis.mapgraph/ref "root.nestedArray.1"}
+                              {:artemis.mapgraph/ref "root.nestedArray.2"}]
                 ::cache      "root"}
-               [::cache "root.nestedArray.0"]
+               "root.nestedArray.0"
                {:object/stringField "this is a string too"
                 :object/numberField 2
                 :object/nullField   nil
-                :object/deeplyNestedArray [[::cache "root.nestedArray.0.deeplyNestedArray.0"]
-                                           [::cache "root.nestedArray.0.deeplyNestedArray.1"]]
+                :object/deeplyNestedArray [{:artemis.mapgraph/ref "root.nestedArray.0.deeplyNestedArray.0"}
+                                           {:artemis.mapgraph/ref "root.nestedArray.0.deeplyNestedArray.1"}]
                 :__typename         "object"
                 ::cache             "root.nestedArray.0"}
-               [::cache "root.nestedArray.1"]
+               "root.nestedArray.1"
                {:object/stringField "this is a string also"
                 :object/numberField 3
                 :object/nullField   nil
-                :object/deeplyNestedArray [[::cache "root.nestedArray.1.deeplyNestedArray.0"]
-                                           [::cache "root.nestedArray.1.deeplyNestedArray.1"]]
+                :object/deeplyNestedArray [{:artemis.mapgraph/ref "root.nestedArray.1.deeplyNestedArray.0"}
+                                           {:artemis.mapgraph/ref "root.nestedArray.1.deeplyNestedArray.1"}]
                 :__typename         "object"
                 ::cache             "root.nestedArray.1"}
-               [::cache "root.nestedArray.2"]
+               "root.nestedArray.2"
                {:object/stringField       "this is a string, man"
                 :object/numberField       6
                 :object/nullField         nil
                 :object/deeplyNestedArray []
                 :__typename               "object"
                 ::cache                   "root.nestedArray.2"}
-               [::cache "root.nestedArray.0.deeplyNestedArray.0"]
+               "root.nestedArray.0.deeplyNestedArray.0"
                {:numberField 10
                 :stringField "Foo"
                 ::cache      "root.nestedArray.0.deeplyNestedArray.0"}
-               [::cache "root.nestedArray.0.deeplyNestedArray.1"]
+               "root.nestedArray.0.deeplyNestedArray.1"
                {:numberField 20
                 :stringField "Bar"
                 ::cache      "root.nestedArray.0.deeplyNestedArray.1"}
-               [::cache "root.nestedArray.1.deeplyNestedArray.0"]
+               "root.nestedArray.1.deeplyNestedArray.0"
                {:numberField 30
                 :stringField "Baz"
                 ::cache      "root.nestedArray.1.deeplyNestedArray.0"}
-               [::cache "root.nestedArray.1.deeplyNestedArray.1"]
+               "root.nestedArray.1.deeplyNestedArray.1"
                {:numberField 40
                 :stringField "Boo"
                 ::cache      "root.nestedArray.1.deeplyNestedArray.1"}}}
@@ -461,21 +461,21 @@
                               :numberField 3
                               :nullField   nil
                               :__typename  "object"}]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 1
                 :nullField   nil
-                :nestedArray [[::cache "root.nestedArray.0"]
-                              [::cache "root.nestedArray.1"]]
+                :nestedArray [{:artemis.mapgraph/ref "root.nestedArray.0"}
+                              {:artemis.mapgraph/ref "root.nestedArray.1"}]
                 ::cache      "root"}
-               [::cache "root.nestedArray.0"]
+               "root.nestedArray.0"
                {:object/stringField "this is a string too"
                 :object/numberField 2
                 :object/nullField   nil
                 :__typename         "object"
                 ::cache             "root.nestedArray.0"}
-               [::cache "root.nestedArray.1"]
+               "root.nestedArray.1"
                {:object/stringField "this is a string also"
                 :object/numberField 3
                 :object/nullField   nil
@@ -504,15 +504,15 @@
                               :numberField 3
                               :nullField   nil
                               :__typename  "object"}]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 1
                 :nullField   nil
                 :nestedArray [nil
-                              [::cache "root.nestedArray.1"]]
+                              {:artemis.mapgraph/ref "root.nestedArray.1"}]
                 ::cache      "root"}
-               [::cache "root.nestedArray.1"]
+               "root.nestedArray.1"
                {:object/stringField "this is a string also"
                 :object/numberField 3
                 :object/nullField   nil
@@ -533,7 +533,7 @@
                :numberField 3
                :nullField   nil
                :simpleArray ["one" "two" "three"]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
@@ -555,7 +555,7 @@
                :numberField 3
                :nullField   nil
                :simpleArray [nil "two" "three"]}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
@@ -584,12 +584,12 @@
                          :numberField 1
                          :__typename  "object"}}
 
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id      "a"
-                :object1 [:object/id "aa"]
-                :object2 [:object/id "aa"]
+                :object1 {:artemis.mapgraph/ref "aa"}
+                :object2 {:artemis.mapgraph/ref "aa"}
                 ::cache  "root"}
-               [:object/id "aa"]
+               "aa"
                {:object/id          "aa"
                 :object/stringField "this is a string"
                 :object/numberField 1
@@ -630,22 +630,22 @@
                                        :__typename  "nested-object"}
                          :__typename  "object"}]}
 
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id     "a"
-                :array1 [[:object/id "aa"]]
-                :array2 [[:object/id "ab"]]
+                :array1 [{:artemis.mapgraph/ref "aa"}]
+                :array2 [{:artemis.mapgraph/ref "ab"}]
                 ::cache "root"}
-               [:object/id "aa"]
+               "aa"
                {:object/id          "aa"
                 :object/stringField "this is a string"
-                :object/obj         [:nested-object/id "aaa"]
+                :object/obj         {:artemis.mapgraph/ref "aaa"}
                 :__typename         "object"}
-               [:object/id "ab"]
+               "ab"
                {:object/id          "ab"
                 :object/stringField "this is a string too"
-                :object/obj         [:nested-object/id "aaa"]
+                :object/obj         {:artemis.mapgraph/ref "aaa"}
                 :__typename         "object"}
-               [:nested-object/id "aaa"]
+               "aaa"
                {:nested-object/id          "aaa"
                 :nested-object/stringField "string"
                 :nested-object/numberField 1
@@ -670,7 +670,7 @@
                :numberField 3
                :nullField   nil
                :nestedObj   nil}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
@@ -699,14 +699,15 @@
                   {:id          "efgh"
                    :numberField 3
                    :__typename  "otherobject"}]}
-      :entities {[::cache "root"]
-                 {"search({\"text\":\"a\"})" [[:object/id "abcd"] [:otherobject/id "efgh"]]
+      :entities {"root"
+                 {"search({\"text\":\"a\"})" [{:artemis.mapgraph/ref "abcd"}
+                                              {:artemis.mapgraph/ref "efgh"}]
                   ::cache                    "root"}
-                 [:object/id "abcd"]
+                 "abcd"
                  {:object/id          "abcd"
                   :object/stringField "this is a string"
                   :__typename         "object"}
-                 [:otherobject/id "efgh"]
+                 "efgh"
                  {:otherobject/id          "efgh"
                   :otherobject/numberField 3
                   :__typename              "otherobject"}}}
@@ -725,15 +726,15 @@
                    :__typename  "someobject"}
                   {:stringField "this is another string"
                    :__typename  "someobject"}]}
-      :entities {[::cache "root"]
-                 {"search({\"text\":\"a\"})" [[::cache "root.search({\"text\":\"a\"}).0"]
-                                              [::cache "root.search({\"text\":\"a\"}).1"]]
+      :entities {"root"
+                 {"search({\"text\":\"a\"})" [{:artemis.mapgraph/ref "root.search({\"text\":\"a\"}).0"}
+                                              {:artemis.mapgraph/ref "root.search({\"text\":\"a\"}).1"}]
                   ::cache                    "root"}
-                 [::cache "root.search({\"text\":\"a\"}).0"]
+                 "root.search({\"text\":\"a\"}).0"
                  {:someobject/stringField "this is a string"
                   :__typename             "someobject"
                   ::cache                 "root.search({\"text\":\"a\"}).0"}
-                 [::cache "root.search({\"text\":\"a\"}).1"]
+                 "root.search({\"text\":\"a\"}).1"
                  {:someobject/stringField "this is another string"
                   :__typename             "someobject"
                   ::cache                 "root.search({\"text\":\"a\"}).1"}}}
@@ -761,12 +762,12 @@
                                :stringField "this is a string"
                                :numberField 3
                                :__typename  "object"}}
-      :entities {[::cache "root"]
+      :entities {"root"
                  {:id          "a"
                   :stringField "this is a string"
-                  :unionObj    [:object/id "abcd"]
+                  :unionObj    {:artemis.mapgraph/ref "abcd"}
                   ::cache      "root"}
-                 [:object/id "abcd"]
+                 "abcd"
                  {:object/id          "abcd"
                   :object/stringField "this is a string"
                   :object/numberField 3
@@ -792,12 +793,12 @@
                  :unionObj    {:stringField "this is a string"
                                :numberField 3
                                :__typename  "someobject"}}
-      :entities {[::cache "root"]
+      :entities {"root"
                  {:id          "a"
                   :stringField "this is a string"
-                  :unionObj    [::cache "root.unionObj"]
+                  :unionObj    {:artemis.mapgraph/ref "root.unionObj"}
                   ::cache      "root"}
-                 [::cache "root.unionObj"]
+                 "root.unionObj"
                  {:someobject/stringField "this is a string"
                   :someobject/numberField 3
                   :__typename             "someobject"
@@ -817,7 +818,7 @@
     :result   {:id          "abcd"
                :stringField "this is a string"
                :numberField 3}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
@@ -842,11 +843,11 @@
                            :stringField "this is a string"
                            :numberField 3
                            :__typename  "object"}}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id        "abcd"
-                :nestedObj [:object/id "abcde"]
+                :nestedObj {:artemis.mapgraph/ref "abcde"}
                 ::cache    "root"}
-               [:object/id "abcde"]
+               "abcde"
                {:object/id          "abcde"
                 :object/stringField "this is a string"
                 :object/numberField 3
@@ -871,17 +872,21 @@
     :result   {:id          "abcd"
                :stringField "this is a string"
                :numberField 3}
-    :entities {[::cache "root"]
+    :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
                 :numberField 3
                 ::cache      "root"}}}
 })
 
+(defn- id-fn [o]
+  (let [k (first (filter #(% o) [:object/id :nested-object/id :otherobject/id]))]
+    (get o k)))
+
 (defn write-test [k]
   (testing (str "testing normalized cache persistence for query type: " k)
     (let [{:keys [query input-vars result entities]} (get test-queries k)
-          initial-store (create-store :id-attrs #{:object/id :nested-object/id :otherobject/id}
+          initial-store (create-store :id-fn id-fn
                                       :cache-key ::cache)
           new-store (a/write initial-store {:data result} query input-vars)]
       (is (= entities (:entities new-store))))))
@@ -893,7 +898,7 @@
 (defn read-test [k]
   (testing (str "testing normalized cache querying for query type: " k)
     (let [{:keys [query input-vars result entities]} (get test-queries k)
-          store (create-store :id-attrs #{:object/id :nested-object/id}
+          store (create-store :id-fn id-fn
                               :entities entities
                               :cache-key ::cache)
           response (a/read store query input-vars)]
@@ -909,13 +914,13 @@
                    "fragment A on object {
                       stringField
                     }")
-    :entities    {[:object/id "abcde"]
+    :entities    {"abcde"
                   {:id          "abcde"
                    :stringField "this is a string"
                    :numberField 3
                    :nullField   nil
                    ::cache      "root"}}
-    :entity      [:object/id "abcde"]
+    :entity      "abcde"
     :write-data  {:stringField "this is a different string"}
     :read-result {:stringField "this is a string"}}
 
@@ -925,11 +930,11 @@
                       numberField
                       stringField
                     }")
-    :entities    {[:object/id "abcde"]
+    :entities    {"abcde"
                   {:object/id          "abcde"
                    :object/stringField "this is a string"
                    :object/numberField 3}}
-    :entity      [:object/id "abcde"]
+    :entity      "abcde"
     :write-data  {:stringField "this is a different string"
                   :numberField 4}
     :read-result {:stringField "this is a string"
@@ -938,7 +943,7 @@
 (defn write-fragment-test [k]
   (testing (str "testing normalized cache persistence for fragment type: " k)
     (let [{:keys [fragment entity write-data entities]} (get test-fragments k)
-          initial-store (create-store :id-attrs #{:object/id :nested-object/id :otherobject/id}
+          initial-store (create-store :id-fn id-fn
                                       :entities entities
                                       :cache-key ::cache)
           old-ent (get (:entities initial-store) entity)
@@ -953,7 +958,7 @@
 (defn read-fragment-test [k]
   (testing (str "testing normalized cache reading for fragment type: " k)
     (let [{:keys [fragment entity entities read-result]} (get test-fragments k)
-          store (create-store :id-attrs #{:object/id :nested-object/id :otherobject/id}
+          store (create-store :id-fn id-fn
                               :entities entities
                               :cache-key ::cache)
           response (a/read-fragment store fragment entity)]

--- a/test/artemis/stores/mapgraph_store_test.cljs
+++ b/test/artemis/stores/mapgraph_store_test.cljs
@@ -171,8 +171,7 @@
                :nestedObj   {:id          "abcde"
                              :stringField "this is a string too"
                              :numberField 3
-                             :nullField   nil
-                             :__typename  "object"}}
+                             :nullField   nil}}
     :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
@@ -181,11 +180,10 @@
                 :nestedObj   {:artemis.mapgraph/ref "abcde"}
                 ::cache      "root"}
                "abcde"
-               {:object/id          "abcde"
-                :object/stringField "this is a string too"
-                :object/numberField 3
-                :object/nullField   nil
-                :__typename         "object"}}}
+               {:id          "abcde"
+                :stringField "this is a string too"
+                :numberField 3
+                :nullField   nil}}}
 
    :nested-no-id
    {:query    (d/parse-document
@@ -206,8 +204,7 @@
                :nullField   nil
                :nestedObj   {:stringField "this is a string too"
                              :numberField 3
-                             :nullField   nil
-                             :__typename  "object"}}
+                             :nullField   nil}}
     :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
@@ -216,10 +213,9 @@
                 :nestedObj   {:artemis.mapgraph/ref "root.nestedObj"}
                 ::cache      "root"}
                "root.nestedObj"
-               {:object/stringField "this is a string too"
-                :object/numberField 3
-                :object/nullField   nil
-                :__typename         "object"
+               {:stringField "this is a string too"
+                :numberField 3
+                :nullField   nil
                 ::cache             "root.nestedObj"}}}
 
    :nested-with-args
@@ -241,8 +237,7 @@
                :nullField   nil
                :nestedObj   {:stringField "this is a string too"
                              :numberField 3
-                             :nullField   nil
-                             :__typename  "object"}}
+                             :nullField   nil}}
     :entities {"root"
                {:id                            "abcd"
                 :stringField                   "this is a string"
@@ -251,10 +246,9 @@
                 "nestedObj({\"arg\":\"val\"})" {:artemis.mapgraph/ref "root.nestedObj({\"arg\":\"val\"})"}
                 ::cache                        "root"}
                "root.nestedObj({\"arg\":\"val\"})"
-               {:object/stringField "this is a string too"
-                :object/numberField 3
-                :object/nullField   nil
-                :__typename         "object"
+               {:stringField "this is a string too"
+                :numberField 3
+                :nullField   nil
                 ::cache             "root.nestedObj({\"arg\":\"val\"})"}}}
 
    :nested-array
@@ -278,13 +272,11 @@
                :nestedArray [{:id          "abcde"
                               :stringField "this is a string too"
                               :numberField 2
-                              :nullField   nil
-                              :__typename  "object"}
+                              :nullField   nil}
                              {:id          "abcdef"
                               :stringField "this is a string also"
                               :numberField 3
-                              :nullField   nil
-                              :__typename  "object"}]}
+                              :nullField   nil}]}
     :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
@@ -294,17 +286,15 @@
                               {:artemis.mapgraph/ref "abcdef"}]
                 ::cache      "root"}
                "abcde"
-               {:object/id          "abcde"
-                :object/stringField "this is a string too"
-                :object/numberField 2
-                :object/nullField   nil
-                :__typename         "object"}
+               {:id          "abcde"
+                :stringField "this is a string too"
+                :numberField 2
+                :nullField   nil}
                "abcdef"
-               {:object/id          "abcdef"
-                :object/stringField "this is a string also"
-                :object/numberField 3
-                :object/nullField   nil
-                :__typename         "object"}}}
+               {:id          "abcdef"
+                :stringField "this is a string also"
+                :numberField 3
+                :nullField   nil}}}
 
    :nested-array-with-null
    {:query    (d/parse-document
@@ -327,8 +317,7 @@
                :nestedArray [{:id          "abcde"
                               :stringField "this is a string too"
                               :numberField 2
-                              :nullField   nil
-                              :__typename  "object"}
+                              :nullField   nil}
                              nil]}
     :entities {"root"
                {:id          "abcd"
@@ -338,11 +327,10 @@
                 :nestedArray [{:artemis.mapgraph/ref "abcde"} nil]
                 ::cache      "root"}
                "abcde"
-               {:object/id          "abcde"
-                :object/stringField "this is a string too"
-                :object/numberField 2
-                :object/nullField   nil
-                :__typename         "object"}}}
+               {:id          "abcde"
+                :stringField "this is a string too"
+                :numberField 2
+                :nullField   nil}}}
 
    :deeply-nested-array
    {:query    (d/parse-document
@@ -371,22 +359,19 @@
                               :deeplyNestedArray [{:numberField 10
                                                    :stringField "Foo"}
                                                   {:numberField 20
-                                                   :stringField "Bar"}]
-                              :__typename        "object"}
+                                                   :stringField "Bar"}]}
                              {:stringField       "this is a string also"
                               :numberField       3
                               :deeplyNestedArray [{:numberField 30
                                                    :stringField "Baz"}
                                                   {:numberField 40
                                                    :stringField "Boo"}]
-                              :nullField         nil
-                              :__typename        "object"}
+                              :nullField         nil}
 
                              {:stringField       "this is a string, man"
                               :numberField       6
                               :deeplyNestedArray []
-                              :nullField         nil
-                              :__typename        "object"}]}
+                              :nullField         nil}]}
     :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
@@ -397,28 +382,25 @@
                               {:artemis.mapgraph/ref "root.nestedArray.2"}]
                 ::cache      "root"}
                "root.nestedArray.0"
-               {:object/stringField "this is a string too"
-                :object/numberField 2
-                :object/nullField   nil
-                :object/deeplyNestedArray [{:artemis.mapgraph/ref "root.nestedArray.0.deeplyNestedArray.0"}
-                                           {:artemis.mapgraph/ref "root.nestedArray.0.deeplyNestedArray.1"}]
-                :__typename         "object"
+               {:stringField "this is a string too"
+                :numberField 2
+                :nullField   nil
+                :deeplyNestedArray [{:artemis.mapgraph/ref "root.nestedArray.0.deeplyNestedArray.0"}
+                                    {:artemis.mapgraph/ref "root.nestedArray.0.deeplyNestedArray.1"}]
                 ::cache             "root.nestedArray.0"}
                "root.nestedArray.1"
-               {:object/stringField "this is a string also"
-                :object/numberField 3
-                :object/nullField   nil
-                :object/deeplyNestedArray [{:artemis.mapgraph/ref "root.nestedArray.1.deeplyNestedArray.0"}
-                                           {:artemis.mapgraph/ref "root.nestedArray.1.deeplyNestedArray.1"}]
-                :__typename         "object"
+               {:stringField "this is a string also"
+                :numberField 3
+                :nullField   nil
+                :deeplyNestedArray [{:artemis.mapgraph/ref "root.nestedArray.1.deeplyNestedArray.0"}
+                                    {:artemis.mapgraph/ref "root.nestedArray.1.deeplyNestedArray.1"}]
                 ::cache             "root.nestedArray.1"}
                "root.nestedArray.2"
-               {:object/stringField       "this is a string, man"
-                :object/numberField       6
-                :object/nullField         nil
-                :object/deeplyNestedArray []
-                :__typename               "object"
-                ::cache                   "root.nestedArray.2"}
+               {:stringField       "this is a string, man"
+                :numberField       6
+                :nullField         nil
+                :deeplyNestedArray []
+                ::cache            "root.nestedArray.2"}
                "root.nestedArray.0.deeplyNestedArray.0"
                {:numberField 10
                 :stringField "Foo"
@@ -455,12 +437,10 @@
                :nullField   nil
                :nestedArray [{:stringField "this is a string too"
                               :numberField 2
-                              :nullField   nil
-                              :__typename  "object"}
+                              :nullField   nil}
                              {:stringField "this is a string also"
                               :numberField 3
-                              :nullField   nil
-                              :__typename  "object"}]}
+                              :nullField   nil}]}
     :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
@@ -470,17 +450,15 @@
                               {:artemis.mapgraph/ref "root.nestedArray.1"}]
                 ::cache      "root"}
                "root.nestedArray.0"
-               {:object/stringField "this is a string too"
-                :object/numberField 2
-                :object/nullField   nil
-                :__typename         "object"
-                ::cache             "root.nestedArray.0"}
+               {:stringField "this is a string too"
+                :numberField 2
+                :nullField   nil
+                ::cache      "root.nestedArray.0"}
                "root.nestedArray.1"
-               {:object/stringField "this is a string also"
-                :object/numberField 3
-                :object/nullField   nil
-                :__typename         "object"
-                ::cache             "root.nestedArray.1"}}}
+               {:stringField "this is a string also"
+                :numberField 3
+                :nullField   nil
+                ::cache      "root.nestedArray.1"}}}
 
    :nested-array-with-nulls-and-no-ids
    {:query    (d/parse-document
@@ -502,8 +480,7 @@
                :nestedArray [nil
                              {:stringField "this is a string also"
                               :numberField 3
-                              :nullField   nil
-                              :__typename  "object"}]}
+                              :nullField   nil}]}
     :entities {"root"
                {:id          "abcd"
                 :stringField "this is a string"
@@ -513,11 +490,10 @@
                               {:artemis.mapgraph/ref "root.nestedArray.1"}]
                 ::cache      "root"}
                "root.nestedArray.1"
-               {:object/stringField "this is a string also"
-                :object/numberField 3
-                :object/nullField   nil
-                :__typename         "object"
-                ::cache             "root.nestedArray.1"}}}
+               {:stringField "this is a string also"
+                :numberField 3
+                :nullField   nil
+                ::cache      "root.nestedArray.1"}}}
 
    :simple-array
    {:query    (d/parse-document
@@ -578,11 +554,9 @@
                  }")
     :result   {:id      "a"
                :object1 {:id          "aa"
-                         :stringField "this is a string"
-                         :__typename  "object"}
+                         :stringField "this is a string"}
                :object2 {:id          "aa"
-                         :numberField 1
-                         :__typename  "object"}}
+                         :numberField 1}}
 
     :entities {"root"
                {:id      "a"
@@ -590,10 +564,9 @@
                 :object2 {:artemis.mapgraph/ref "aa"}
                 ::cache  "root"}
                "aa"
-               {:object/id          "aa"
-                :object/stringField "this is a string"
-                :object/numberField 1
-                :__typename         "object"}}}
+               {:id          "aa"
+                :stringField "this is a string"
+                :numberField 1}}}
 
    :obj-in-different-array-paths
    {:query    (d/parse-document
@@ -620,15 +593,11 @@
                :array1 [{:id          "aa"
                          :stringField "this is a string"
                          :obj         {:id          "aaa"
-                                       :stringField "string"
-                                       :__typename  "nested-object"}
-                         :__typename  "object"}]
+                                       :stringField "string"}}]
                :array2 [{:id          "ab"
                          :stringField "this is a string too"
                          :obj         {:id          "aaa"
-                                       :numberField 1
-                                       :__typename  "nested-object"}
-                         :__typename  "object"}]}
+                                       :numberField 1}}]}
 
     :entities {"root"
                {:id     "a"
@@ -636,20 +605,17 @@
                 :array2 [{:artemis.mapgraph/ref "ab"}]
                 ::cache "root"}
                "aa"
-               {:object/id          "aa"
-                :object/stringField "this is a string"
-                :object/obj         {:artemis.mapgraph/ref "aaa"}
-                :__typename         "object"}
+               {:id          "aa"
+                :stringField "this is a string"
+                :obj         {:artemis.mapgraph/ref "aaa"}}
                "ab"
-               {:object/id          "ab"
-                :object/stringField "this is a string too"
-                :object/obj         {:artemis.mapgraph/ref "aaa"}
-                :__typename         "object"}
+               {:id          "ab"
+                :stringField "this is a string too"
+                :obj         {:artemis.mapgraph/ref "aaa"}}
                "aaa"
-               {:nested-object/id          "aaa"
-                :nested-object/stringField "string"
-                :nested-object/numberField 1
-                :__typename                "nested-object"}}}
+               {:id          "aaa"
+                :stringField "string"
+                :numberField 1}}}
 
    :nested-object-returning-null
    {:query    (d/parse-document
@@ -685,10 +651,12 @@
                        ... on object {
                          id
                          stringField
+                         __typename
                        }
                        ... on otherobject {
                          id
                          numberField
+                         __typename
                        }
                      }
                    }")
@@ -704,13 +672,13 @@
                                               {:artemis.mapgraph/ref "efgh"}]
                   ::cache                    "root"}
                  "abcd"
-                 {:object/id          "abcd"
-                  :object/stringField "this is a string"
-                  :__typename         "object"}
+                 {:id          "abcd"
+                  :stringField "this is a string"
+                  :__typename  "object"}
                  "efgh"
-                 {:otherobject/id          "efgh"
-                  :otherobject/numberField 3
-                  :__typename              "otherobject"}}}
+                 {:id          "efgh"
+                  :numberField 3
+                  :__typename  "otherobject"}}}
 
      :union-array-no-id
      {:query    (d/parse-document
@@ -718,6 +686,7 @@
                      search(text: \"a\") {
                        ... on someobject {
                          stringField
+                         __typename
                        }
                      }
                    }")
@@ -731,13 +700,13 @@
                                               {:artemis.mapgraph/ref "root.search({\"text\":\"a\"}).1"}]
                   ::cache                    "root"}
                  "root.search({\"text\":\"a\"}).0"
-                 {:someobject/stringField "this is a string"
-                  :__typename             "someobject"
-                  ::cache                 "root.search({\"text\":\"a\"}).0"}
+                 {:stringField "this is a string"
+                  :__typename  "someobject"
+                  ::cache      "root.search({\"text\":\"a\"}).0"}
                  "root.search({\"text\":\"a\"}).1"
-                 {:someobject/stringField "this is another string"
-                  :__typename             "someobject"
-                  ::cache                 "root.search({\"text\":\"a\"}).1"}}}
+                 {:stringField "this is another string"
+                  :__typename  "someobject"
+                  ::cache      "root.search({\"text\":\"a\"}).1"}}}
 
      :nested-union
      {:query    (d/parse-document
@@ -749,10 +718,12 @@
                          id
                          numberField
                          stringField
+                         __typename
                        }
                        ... on otherobject {
                          id
                          stringField
+                         __typename
                        }
                      }
                    }")
@@ -768,10 +739,10 @@
                   :unionObj    {:artemis.mapgraph/ref "abcd"}
                   ::cache      "root"}
                  "abcd"
-                 {:object/id          "abcd"
-                  :object/stringField "this is a string"
-                  :object/numberField 3
-                  :__typename         "object"}}}
+                 {:id          "abcd"
+                  :stringField "this is a string"
+                  :numberField 3
+                  :__typename  "object"}}}
 
      :nested-union-no-id
      {:query    (d/parse-document
@@ -782,9 +753,11 @@
                        ... on someobject {
                          numberField
                          stringField
+                         __typename
                        }
                        ... on someotherobject {
                          stringField
+                         __typename
                        }
                      }
                    }")
@@ -799,10 +772,10 @@
                   :unionObj    {:artemis.mapgraph/ref "root.unionObj"}
                   ::cache      "root"}
                  "root.unionObj"
-                 {:someobject/stringField "this is a string"
-                  :someobject/numberField 3
-                  :__typename             "someobject"
-                  ::cache                 "root.unionObj"}}}
+                 {:stringField "this is a string"
+                  :numberField 3
+                  :__typename  "someobject"
+                  ::cache      "root.unionObj"}}}
 
    :fragments
    {:query    (d/parse-document
@@ -841,17 +814,15 @@
     :result   {:id        "abcd"
                :nestedObj {:id          "abcde"
                            :stringField "this is a string"
-                           :numberField 3
-                           :__typename  "object"}}
+                           :numberField 3}}
     :entities {"root"
                {:id        "abcd"
                 :nestedObj {:artemis.mapgraph/ref "abcde"}
                 ::cache    "root"}
                "abcde"
-               {:object/id          "abcde"
-                :object/stringField "this is a string"
-                :object/numberField 3
-                :__typename         "object"}}}
+               {:id          "abcde"
+                :stringField "this is a string"
+                :numberField 3}}}
 
    :chained-fragments
    {:query    (d/parse-document
@@ -880,8 +851,7 @@
 })
 
 (defn- id-fn [o]
-  (let [k (first (filter #(% o) [:object/id :nested-object/id :otherobject/id]))]
-    (get o k)))
+  (:id o))
 
 (defn write-test [k]
   (testing (str "testing normalized cache persistence for query type: " k)
@@ -931,9 +901,9 @@
                       stringField
                     }")
     :entities    {"abcde"
-                  {:object/id          "abcde"
-                   :object/stringField "this is a string"
-                   :object/numberField 3}}
+                  {:id          "abcde"
+                   :stringField "this is a string"
+                   :numberField 3}}
     :entity      "abcde"
     :write-data  {:stringField "this is a different string"
                   :numberField 4}


### PR DESCRIPTION
This isn't a lot of code, but it's a pretty big change.

Standard mapgraph asks you to pass a set of keywords that it uses as a sort of reference index. Whenever it encounters a map that contains any of those keywords, it creates a referece and noramlizes. This PR departs from that approach and instead allows you to specify a function that resolves the key to store an entity ad-hoc, instead of just using the value for a key. This is more like Apollo client does it.

Because the function could return any value, it isn't safe to just use the resulting id as a reference to the normalized entity, so references are contained within a map with a single key `:artemis.mapgraph/ref`. For example:

```cljs
;; using :id as the id-fn

{1
 {:id 1
  :name "Pebbles"
  :mother {:artemis.mapgraph/ref 2}
  :father {:atermis.mapgraph/ref 3}}
 2
 {:id 2
  :name "Wilma"}
 3
 {:id 3
  :name "Fred"}}
```

This is cool, because we're no longer limited by entity keys for creating references, and because of that we don't have to worry about keys clashing between different entities. All of that means that we no longer have to use `__typename` to normalize.

For us, it also means we can easily use `:dbId` to normalize on. For others they can use whatever they want, including typename if that's what they desire. For illustration purpose, here's how to build up the exact same entity keys as the current mapgraph approach does:

```clj
(defn- find-id-attr [m id-attrs]
  (some #(when (fn [x] (contains? m x) x) id-attrs))

(defn- id-fn [entity]
 (when-let [k (find-id-attr entity #{:slug :id :something-else})
  [(keyword (:__typename entity) k) (get entity k]))

(create-store :id-fn id-fn)
```

Still have to go through and update a lot of docs if we go with this.