### PR TITLE
fix bug with pull-join returning ::incomplete-value

### DIFF
--- a/src/artemis/stores/mapgraph/read.cljs
+++ b/src/artemis/stores/mapgraph/read.cljs
@@ -154,7 +154,10 @@
                 (reduced ::incomplete-value)))
 
             (map? expr)
-            (pull-join store result expr entity gql-context)
+            (let [map-result (pull-join store result expr entity gql-context)]
+              (if (= map-result ::incomplete-value)
+                (reduced map-result)
+                map-result))
 
             (= '* expr)                                     ; don't re-merge things we already joined
             (merge result (apply dissoc entity (keys result)))

--- a/src/artemis/stores/mapgraph/read.cljs
+++ b/src/artemis/stores/mapgraph/read.cljs
@@ -155,7 +155,7 @@
 
             (map? expr)
             (let [map-result (pull-join store result expr entity gql-context)]
-              (if (= map-result ::incomplete-value)
+              (if (incomplete? map-result)
                 (reduced map-result)
                 map-result))
 

--- a/test/artemis/stores/mapgraph_store_test.cljs
+++ b/test/artemis/stores/mapgraph_store_test.cljs
@@ -1022,10 +1022,10 @@
       (testing "set to false all data not present deeply"
         (let [query (d/parse-document "{
                                         object1 {
-                                          id
                                           otherObject {
                                             title
                                           }
+                                          id
                                         }
                                       }")]
           (is (nil? (:data (a/read store query {})))))))


### PR DESCRIPTION
this should fix @dkozma's current issue. basically what happens is that sometimes `pull-join` returns `::incomplete-value`. That value becomes the new result in the reduce and later the reducing fn fails when trying to assoc onto what it thinks is a map but is actually a keyword

I modified a test slightly to capture this bug
![screen shot 2018-07-31 at 3 37 11 pm](https://user-images.githubusercontent.com/1201876/43482934-20c28ebe-94d8-11e8-8a6f-427ea14777dc.png)
 
I also figured out why sometimes `pull` returns a list of values that are all `::incomplete-value`. That issue is closely tied to the following story, and should be fixed alongside it. (https://app.clubhouse.io/workframe/story/15192/artemis-should-re-query-the-server-when-it-receives-incomplete-values-using-local-first)