### PR TITLE
Add on-response hook for the default HttpNetworkStep

### DIFF
--- a/src/artemis/network_steps/http.cljs
+++ b/src/artemis/network_steps/http.cljs
@@ -24,11 +24,11 @@
 (defrecord
   ^{:added "0.1.0"}
   HttpNetworkStep
-  [uri on-response]
+  [uri opts]
   np/GQLNetworkStep
   (-exec [this operation context]
     (let [next (fn [data errors meta]
-                 (let [on-response (:on-response this)]
+                 (let [on-response (some-> this :opts :on-response)]
                    (when (fn? on-response)
                      (on-response data errors meta))
                    (ar/with-errors data errors)))
@@ -58,5 +58,7 @@
   {:added "0.1.0"}
   ([]
    (create-network-step "/graphql"))
-  ([uri & [on-response]]
-   (HttpNetworkStep. uri on-response)))
+  ([uri]
+   (create-network-step uri {}))
+  ([uri opts]
+   (HttpNetworkStep. uri opts)))

--- a/src/artemis/network_steps/http.cljs
+++ b/src/artemis/network_steps/http.cljs
@@ -24,24 +24,32 @@
 (defrecord
   ^{:added "0.1.0"}
   HttpNetworkStep
-  [uri]
+  [uri on-response]
   np/GQLNetworkStep
   (-exec [this operation context]
-    (try
-      (let [c (post-operation this operation context)]
-        (go (let [{:keys [body error-code] :as res} (async/<! c)
-                  net-error   (when (not= error-code :no-error)
-                                {:message (str "Network error " error-code)
+    (let [next (fn [data errors meta]
+                 (let [on-response (:on-response this)]
+                   (when (fn? on-response)
+                     (on-response data errors meta))
+                   (ar/with-errors data errors)))
+          meta {:operation operation
+                :context   context}]
+      (try
+        (let [c (post-operation this operation context)]
+          (go (let [{:keys [body error-code] :as res} (async/<! c)
+                    net-error (when (not= error-code :no-error)
+                                {:message  (str "Network error " error-code)
                                  :response res})
-                  unpack      (:unpack operation)
-                  data        (unpack (:data body))
-                  errors      (into (:errors body) net-error)]
-              (ar/with-errors {:data data} errors))))
-      (catch :default e
-        (async/to-chan
-         [(ar/with-errors
-           {:data nil}
-           [(assoc (ex-data e) :message (.-message e))])])))))
+                    unpack    (:unpack operation)
+                    data      (unpack (:data body))
+                    errors    (into (:errors body) net-error)]
+                (next {:data data} errors (merge meta {:response res})))))
+        (catch :default e
+          (async/to-chan
+           [(next
+             {:data nil}
+             [(assoc (ex-data e) :message (.-message e))]
+             meta)]))))))
 
 ;; Public API
 (defn create-network-step
@@ -50,5 +58,5 @@
   {:added "0.1.0"}
   ([]
    (create-network-step "/graphql"))
-  ([uri]
-   (HttpNetworkStep. uri)))
+  ([uri & [on-response]]
+   (HttpNetworkStep. uri on-response)))


### PR DESCRIPTION
I want to add the ability to process every GraphQL response that comes back so that we can have metadata around timing, and keep track of when requests complete so polling doesn't get backed up. Since the HttpNetworkStep is the last step that happens, it returns the data back to the client and terminates the network chain, so I don't think I can add a step after it (like response middleware). However, I could be misunderstanding this and there might be a better solution that plays nicely with `GQLNetworkStep`s.

This should be backwards compatible since it only adds an extra optional argument to a function which currently takes none.