### PR TITLE
Properly support :local-first fetch policy when doing partial reads

### DIFF
--- a/src/artemis/stores/mapgraph/core.cljs
+++ b/src/artemis/stores/mapgraph/core.cljs
@@ -12,9 +12,9 @@
   [id-fn entities cache-redirects cache-key]
   sp/GQLStore
   (-read [this document variables return-partial?]
-    {:data (not-empty (read-from-cache document variables this return-partial?))})
+    (read-from-cache document variables this return-partial?))
   (-read-fragment [this document entity-ref return-partial?]
-    {:data (not-empty (read-from-entity document entity-ref this return-partial?))})
+    (read-from-entity document entity-ref this return-partial?))
   (-write [this data document variables]
     (if-let [gql-response (:data data)]
       (write-to-cache document variables gql-response this)

--- a/test/artemis/stores/mapgraph_store_test.cljs
+++ b/test/artemis/stores/mapgraph_store_test.cljs
@@ -866,7 +866,8 @@
           store (create-store :entities entities
                               :cache-key ::cache)
           response (a/read store query input-vars)]
-      (is (= {:data result} response)))))
+      (is (= {:data result
+              :partial? false} response)))))
 
 (deftest test-cache-reading
   (doseq [test-query (keys test-queries)]
@@ -970,7 +971,8 @@
           store (create-store :entities entities
                               :cache-key ::cache)
           response (a/read-fragment store fragment entity)]
-      (is (= {:data read-result} response)))))
+      (is (= {:data read-result
+              :partial? false} response)))))
 
 (deftest test-cache-fragment-reading
   (doseq [test-fragment (keys test-fragments)]

--- a/test/artemis/test_util.cljs
+++ b/test/artemis/test_util.cljs
@@ -27,6 +27,7 @@
     "query Hero($episode: String!) {
       hero(episode: $episode) {
         name
+        title
       }
     }"))
 


### PR DESCRIPTION
this PR builds on top of https://github.com/workframers/artemis/pull/25 (so check that out first)

This is a functional WIP for supporting the `:local-first` fetch policy when `return-partial?` is set to true. The behavior we want is for artemis to requery the server if the cache returns only a partial result from the initial read.

While this PR is functionally complete, I would still like to update the docs and add some tests to cover this case.
