### PR TITLE
haywood/ch18492/inline-fragments-breaks-with-composed-docs

### DIFF
--- a/src/artemis/document.cljc
+++ b/src/artemis/document.cljc
@@ -101,7 +101,7 @@
             sel-set)))
 
 (defn- update-definitions [fragments definitions]
-  (mapv #(assoc % :selection-set (resolve-fragments fragments (:selection-set %)))
+  (mapv #(update % :selection-set (partial resolve-fragments fragments))
         definitions))
 
 (s/fdef inline-fragments

--- a/src/artemis/document.cljc
+++ b/src/artemis/document.cljc
@@ -86,17 +86,23 @@
   (if (empty? fragments)
     sel-set
     (reduce (fn [acc sel]
-              (if (= (:node-type sel) :fragment-spread)
+              (cond
+                (= (:node-type sel) :fragment-spread)
                 (->> (get-in fragments [(:name sel) :selection-set] [])
                      (resolve-fragments fragments)
                      (into acc))
+
+                (not (nil? (:selection-set sel)))
+                (conj acc (update sel :selection-set #(resolve-fragments fragments %)))
+
+                :else
                 (conj acc sel)))
             []
             sel-set)))
 
 (defn- update-definitions [fragments definitions]
-  (map #(assoc % :selection-set (resolve-fragments fragments (:selection-set %)))
-       definitions))
+  (mapv #(assoc % :selection-set (resolve-fragments fragments (:selection-set %)))
+        definitions))
 
 (s/fdef inline-fragments
         :args (s/cat :doc ::document)

--- a/test/artemis/document_test.cljs
+++ b/test/artemis/document_test.cljs
@@ -94,7 +94,46 @@
                                   :field-name "b"}
                                  {:node-type  :field
                                   :field-name "c"}]}]}
-             (d/inline-fragments doc))))))
+             (d/inline-fragments doc)))))
+
+  (testing "inlining composed fragments"
+    (let [frag-one     (d/parse-document "fragment Fields on Thing { b ...MoreFields }")
+          frag-two     (d/parse-document "fragment MoreFields on Thing { c }")
+          doc          (d/parse-document "query SomeQuery { a ...Fields } ")
+          composed-doc (d/compose doc frag-one frag-two)]
+      (is (= {:operation-definitions
+              [{:section        :operation-definitions
+                :node-type      :operation-definition
+                :operation-type {:type "query" :name "SomeQuery"}
+                :selection-set
+                [{:node-type  :field
+                  :field-name "a"}
+                 {:node-type  :field
+                  :field-name "b"}
+                 {:node-type  :field
+                  :field-name "c"}]}]}
+             (d/inline-fragments composed-doc)))))
+
+  (testing "inlining composed fragments with nested selection sets"
+    (let [frag-one     (d/parse-document "fragment Fields on Thing { b ...MoreFields }")
+          frag-two     (d/parse-document "fragment MoreFields on Thing { c }")
+          doc          (d/parse-document "{ me { a ...Fields } } ")
+          composed-doc (d/compose doc frag-one frag-two)]
+      (is (= {:operation-definitions
+              [{:section        :operation-definitions
+                :node-type      :operation-definition
+                :operation-type {:type "query"}
+                :selection-set
+                [{:node-type :field
+                  :field-name "me"
+                  :selection-set
+                  [{:node-type  :field
+                    :field-name "a"}
+                   {:node-type  :field
+                    :field-name "b"}
+                   {:node-type  :field
+                    :field-name "c"}]}]}]}
+             (d/inline-fragments composed-doc))))))
 
 (deftest select
   (testing "a single query"


### PR DESCRIPTION
When trying to inline fragments, my nested fragments were not being inlined, they were being left as fragments. This modifies the resolve fragments call to detect if a field has a selection set, and updates those field's fragments.