### PR TITLE
haywood/ch18497/key-k-found-in-response-but-not-in-document

### DIFF
--- a/test/artemis/document_test.cljs
+++ b/test/artemis/document_test.cljs
@@ -133,6 +133,30 @@
                     :field-name "b"}
                    {:node-type  :field
                     :field-name "c"}]}]}]}
+             (d/inline-fragments composed-doc)))))
+
+  (testing "inlining composed fragments with duplicate fields in separate fragments"
+    (let [frag-one     (d/parse-document "fragment A on Thing { projects {slug} }")
+          frag-two     (d/parse-document "fragment B on Thing { projects {slug name} }")
+          doc          (d/parse-document "{ me { slug ...A ...B } } ")
+          composed-doc (d/compose doc frag-one frag-two)]
+      (is (= {:operation-definitions
+              [{:section        :operation-definitions
+                :node-type      :operation-definition
+                :operation-type {:type "query"}
+                :selection-set
+                [{:node-type :field
+                  :field-name "me"
+                  :selection-set
+                  [{:node-type :field
+                    :field-name "slug"}
+                   {:node-type :field
+                    :field-name "projects"
+                    :selection-set
+                    [{:node-type  :field
+                      :field-name "slug"}
+                     {:node-type  :field
+                      :field-name "name"}]}]}]}]}
              (d/inline-fragments composed-doc))))))
 
 (deftest select


### PR DESCRIPTION
 Error `"Key `" k "` found in response, but not in document."` when different partials ask for different fields from the same resource. If you look at the test, both partials ask for data on the projects field, but previously only the selection set with slug would prevail. The server would respond with name, but name would no longer be in the AST and this error would throw.

The fix is to detect these duplicates and merge their selection sets if they exist.
