### PR TITLE
use specter for map-keys and map-values

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,8 @@
          haslett                         {:mvn/version "0.1.2"}
          shodan                          {:mvn/version "0.4.2"}
          diffit                          {:mvn/version "1.0.0"}
-         floatingpointio/graphql-builder {:mvn/version "0.1.6"}}
+         floatingpointio/graphql-builder {:mvn/version "0.1.6"}
+         com.rpl/specter                 {:mvn/version "1.1.2"}}
 
  :aliases
  {:test

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
    [haslett                         "0.1.2"]
    [shodan                          "0.4.2"]
    [diffit                          "1.0.0"]
-   [floatingpointio/graphql-builder "0.1.6"]]
+   [floatingpointio/graphql-builder "0.1.6"]
+   [com.rpl/specter                 "1.1.2"]]
 
   :exclusions
   [org.clojure/core.async]

--- a/src/artemis/stores/mapgraph/common.cljs
+++ b/src/artemis/stores/mapgraph/common.cljs
@@ -1,7 +1,8 @@
-(ns artemis.stores.mapgraph.common)
+(ns artemis.stores.mapgraph.common
+  (:require [com.rpl.specter :as specter]))
 
-(defn map-vals [m f] (into {} (for [[k v] m] [k (f v)])))
-(defn map-keys [m f] (into {} (for [[k v] m] [(f k) v])))
+(defn map-vals [m f] (specter/transform [specter/MAP-VALS] f m))
+(defn map-keys [m f] (specter/transform [specter/MAP-KEYS] f m))
 
 (defn- possible-entity-map?
   "True if x is a non-sorted map. This check prevents errors from


### PR DESCRIPTION
seeing a ~2x speedup for functions that use map keys, didn't test the performance gain for map values