### PR TITLE
support input variables in read-fragment

### DIFF
--- a/src/artemis/core.cljs
+++ b/src/artemis/core.cljs
@@ -118,8 +118,9 @@
 (defn read-fragment
   "Calls `artemis.stores.protocols/-read-fragment` on a given store."
   {:added "0.1.0"}
-  [store document entity-ref & {:keys [return-partial?] :or {return-partial? false}}]
-  (sp/-read-fragment store document entity-ref return-partial?))
+  [store document entity-ref & {:keys [variables return-partial?]
+                                :or {return-partial? false}}]
+  (sp/-read-fragment store document entity-ref variables return-partial?))
 
 (s/fdef write
         :args (s/cat :store     ::store

--- a/src/artemis/stores/mapgraph/core.cljs
+++ b/src/artemis/stores/mapgraph/core.cljs
@@ -13,8 +13,8 @@
   sp/GQLStore
   (-read [this document variables return-partial?]
     (read-from-cache document variables this return-partial?))
-  (-read-fragment [this document entity-ref return-partial?]
-    (read-from-entity document entity-ref this return-partial?))
+  (-read-fragment [this document entity-ref variables return-partial? ]
+    (read-from-entity document entity-ref variables this return-partial?))
   (-write [this data document variables]
     (if-let [gql-response (:data data)]
       (write-to-cache document variables gql-response this)

--- a/src/artemis/stores/mapgraph/read.cljs
+++ b/src/artemis/stores/mapgraph/read.cljs
@@ -225,13 +225,12 @@
      :partial? partial?}))
 
 (defn read-from-entity
-  [document ent-ref store return-partial?]
+  [document ent-ref input-vars store return-partial?]
   (let [first-frag (-> document :fragment-definitions first)
         fragments (fragments-map document)
-        context {:input-vars {}
-                 :vars-info nil
+        context {:input-vars      input-vars
                  :return-partial? return-partial?
-                 :store store}
+                 :store           store}
         pull-pattern (->gql-pull-pattern first-frag fragments)
         result (pull store pull-pattern {:artemis.mapgraph/ref ent-ref} context)
         partial? (has-incomplete? result)]

--- a/src/artemis/stores/protocols.cljs
+++ b/src/artemis/stores/protocols.cljs
@@ -16,7 +16,7 @@
     If the query cannot be fulfilled at all, i.e. the data does not exist in
     the store, or if `return-partial?` is `false` and the store is not able to
     fulfill the entire query, should return `nil`.")
-  (-read-fragment [this document entity-ref return-partial?]
+  (-read-fragment [this document entity-ref variables return-partial?]
     "Returns the result of a executing a GraphQL fragment against an entity
     identified by `entity-ref`. The store should return a map of `{:data <any>,
     :partial? <boolean>}`.

--- a/test/artemis/stores/mapgraph_store_test.cljs
+++ b/test/artemis/stores/mapgraph_store_test.cljs
@@ -925,48 +925,48 @@
     :read-result {:stringField "this is a string"}}
 
    :nested-fragments
-   {:fragment (d/compose
-               (d/parse-document
-                "fragment A on B {
-                  slug
-                  friends {
-                    ...C
-                  }
-                }")
-               (d/parse-document
-                "fragment C on D {
-                  slug
-                  name
-                  address {
-                    ...D
-                  }
-                }")
-               (d/parse-document
-                "fragment D on E {
-                   zip
-                 }"))
-    :entities {[:slug "abc"]
-               {:slug "abc"
-                :friends [{:artemis.mapgraph/ref [:slug "abcd"]}
-                          {:artemis.mapgraph/ref [:slug "abcde"]}]}
+   {:fragment    (d/compose
+                  (d/parse-document
+                   "fragment A on B {
+                     slug
+                     friends {
+                       ...C
+                     }
+                   }")
+                  (d/parse-document
+                   "fragment C on D {
+                     slug
+                     name
+                     address {
+                       ...D
+                     }
+                   }")
+                  (d/parse-document
+                   "fragment D on E {
+                      zip
+                    }"))
+    :entities    {[:slug "abc"]
+                  {:slug    "abc"
+                   :friends [{:artemis.mapgraph/ref [:slug "abcd"]}
+                             {:artemis.mapgraph/ref [:slug "abcde"]}]}
 
-               [:slug "abcd"]
-               {:slug "abcd"
-                :name "fudge master"
-                :address {:artemis.mapgraph/ref 1}}
+                  [:slug "abcd"]
+                  {:slug    "abcd"
+                   :name    "fudge master"
+                   :address {:artemis.mapgraph/ref 1}}
 
-               1
-               {:id 1 :street "test 1" :zip 11222}
+                  1
+                  {:id 1 :street "test 1" :zip 11222}
 
-               2
-               {:id 2 :street "test 2" :zip 03062}
+                  2
+                  {:id 2 :street "test 2" :zip 03062}
 
-               [:slug "abcde"]
-               {:slug "abcde"
-                :name "fudge colonel"
-                :address {:artemis.mapgraph/ref 2}}}
-    :entity [:slug "abc"]
-    :read-result {:slug "abc"
+                  [:slug "abcde"]
+                  {:slug    "abcde"
+                   :name    "fudge colonel"
+                   :address {:artemis.mapgraph/ref 2}}}
+    :entity      [:slug "abc"]
+    :read-result {:slug    "abc"
                   :friends [{:slug "abcd" :name "fudge master" :address {:zip 11222}}
                             {:slug "abcde" :name "fudge colonel" :address {:zip 03062}}]}}
 
@@ -984,7 +984,34 @@
     :write-data  {:stringField "this is a different string"
                   :numberField 4}
     :read-result {:stringField "this is a string"
-                  :numberField 3}}})
+                  :numberField 3}}
+
+   :fields-with-args
+   {:fragment    (d/parse-document
+                  "fragment A on object {
+                      argField(arg: 1)
+                    }")
+    :entities    {"abcde"
+                  {:id                     "abcde"
+                   "argField({\"arg\":1})" "this is a value 1"
+                   "argField({\"arg\":2})" "this is a value 2"}}
+    :entity      "abcde"
+    :write-data  {:argField "this is a different value"}
+    :read-result {:argField "this is a value 1"}}
+
+   :fields-with-arg-vars
+   {:fragment    (d/parse-document
+                  "fragment A on object {
+                      argField(arg: $argument)
+                    }")
+    :entities    {"abcde"
+                  {:id                     "abcde"
+                   "argField({\"arg\":1})" "this is a value 1"
+                   "argField({\"arg\":2})" "this is a value 2"}}
+    :entity      "abcde"
+    :variables   {:argument 2}
+    :write-data  {:argField "this is a different value"}
+    :read-result {:argField "this is a value 2"}}})
 
 (defn write-fragment-test [k]
   (testing (str "testing normalized cache persistence for fragment type: " k)
@@ -1002,10 +1029,10 @@
 
 (defn read-fragment-test [k]
   (testing (str "testing normalized cache reading for fragment type: " k)
-    (let [{:keys [fragment entity entities read-result]} (get test-fragments k)
+    (let [{:keys [fragment entity entities read-result variables]} (get test-fragments k)
           store (create-store :entities entities
                               :cache-key ::cache)
-          response (a/read-fragment store fragment entity)]
+          response (a/read-fragment store fragment entity :variables variables)]
       (is (= {:data read-result
               :partial? false} response)))))
 


### PR DESCRIPTION
the only relevant change is that now `read-entity` in the mapgraph store and `read-fragment` in artemis' api accept `input-vars` and `variables` respectively